### PR TITLE
Remove pagesize param

### DIFF
--- a/aw_config_sample.py
+++ b/aw_config_sample.py
@@ -13,7 +13,6 @@ AIRWATCH_ALL_SMARTGROUPS = False
 AIRWATCH_USERGROUPS = ["SomeUserGroup"]
 AIRWATCH_SMARTGROUPS = ["SomeSmartGroup"]
 AIRWATCH_USERS_IGNORE = ["Default Staging User", "staging"]
-AIRWATCH_API_REQUEST_PAGESIZE = 500
 
 # Munki paths config
 MANIFEST_DIR = "/path/to/munki/repo/manifests"

--- a/aw_munki_manifest_sync.py
+++ b/aw_munki_manifest_sync.py
@@ -383,17 +383,17 @@ def sync_all_devices(api):
     """Syncs all manifests"""
 
     # Get all AirWatch users
-    rawusers = api.users.search(pagesize=AIRWATCH_API_REQUEST_PAGESIZE)
+    rawusers = api.users.search()
     users = extract_users(rawusers)
 
     # Get desired AirWatch groups
-    rawgroups = api.usergroups.search(pagesize=AIRWATCH_API_REQUEST_PAGESIZE)
+    rawgroups = api.usergroups.search()
     groups = extract_groups(rawgroups)
 
     # Get desired group memberships
     for group in groups.values():
         rawmembers = api.usergroups.search_users(
-            id=group["id"], pagesize=AIRWATCH_API_REQUEST_PAGESIZE
+            id=group["id"],
         )
         if isinstance(rawmembers, dict):
             members = rawmembers["EnrollmentUser"]
@@ -402,22 +402,20 @@ def sync_all_devices(api):
             assign_groups(users, group, members)
 
     # Get all macOS devices
-    rawdevices = api.devices.search_all(
-        platform=AIRWATCH_MAC_PLATFORM, pagesize=AIRWATCH_API_REQUEST_PAGESIZE
-    )
+    rawdevices = api.devices.search_all(platform=AIRWATCH_MAC_PLATFORM)
     devices = extract_devices(rawdevices)
 
     # Assign users to devices
     assign_user(users, devices)
 
     # Get desired AirWatch smartgroups
-    rawsmartgroups = api.smartgroups.search(pagesize=AIRWATCH_API_REQUEST_PAGESIZE)
+    rawsmartgroups = api.smartgroups.search()
     smartgroups = extract_smartgroups(rawsmartgroups)
 
     # Get desired smartgroup memberships
     for smartgroup in smartgroups.values():
         rawsmartmembers = api.smartgroups.get_devices(
-            id=smartgroup["id"], pagesize=AIRWATCH_API_REQUEST_PAGESIZE
+            id=smartgroup["id"],
         )
         if isinstance(rawsmartmembers, dict):
             smartmembers = rawsmartmembers["Devices"]
@@ -462,12 +460,12 @@ def sync_device(api, serial_number):
         # Create users dictionary with single user
         users = {rawdevice["UserName"]: {"name": rawdevice["UserName"], "groups": []}}
         # Get desired AirWatch usergroups
-        rawgroups = api.usergroups.search(pagesize=AIRWATCH_API_REQUEST_PAGESIZE)
+        rawgroups = api.usergroups.search()
         groups = extract_groups(rawgroups)
         # Get desired group memberships
         for group in groups.values():
             rawmembers = api.usergroups.search_users(
-                id=group["id"], pagesize=AIRWATCH_API_REQUEST_PAGESIZE
+                id=group["id"],
             )
             if isinstance(rawmembers, dict):
                 members = rawmembers["EnrollmentUser"]
@@ -478,13 +476,13 @@ def sync_device(api, serial_number):
         handle_user_manifests(users)
 
     # Get desired AirWatch smartgroups
-    rawsmartgroups = api.smartgroups.search(pagesize=AIRWATCH_API_REQUEST_PAGESIZE)
+    rawsmartgroups = api.smartgroups.search()
     smartgroups = extract_smartgroups(rawsmartgroups)
 
     # Get desired smartgroup memberships
     for smartgroup in smartgroups.values():
         rawsmartmembers = api.smartgroups.get_devices(
-            id=smartgroup["id"], pagesize=AIRWATCH_API_REQUEST_PAGESIZE
+            id=smartgroup["id"],
         )
         if isinstance(rawsmartmembers, dict):
             smartmembers = rawsmartmembers["Devices"]


### PR DESCRIPTION
Pagesize no longer needed because [PyVMwareAirWatch](https://github.com/EtneteraLogicworks/PyVMwareAirWatch/tree/cf813f8f543bb5ec600ffb50ba94cc54d0f80eea) now supports pagination. 

Merge only after https://github.com/EtneteraLogicworks/PyVMwareAirWatch/pull/1 is merged and [PyVMwareAirWatch](https://github.com/EtneteraLogicworks/PyVMwareAirWatch/tree/cf813f8f543bb5ec600ffb50ba94cc54d0f80eea) submodule is updated.